### PR TITLE
Simplify Config handling by using the `clap` crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ time = "0.3"
 lazy-regex = "3"
 async-trait = "0.1"
 strum_macros = "0.25"
+clap = { version = "4.4.2", features = ["derive", "env"] }
 
 
 [dev-dependencies]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,60 +1,39 @@
-use crate::{Error, Result};
-use std::env;
-use std::str::FromStr;
+use clap::Parser;
 use std::sync::OnceLock;
 
 pub fn config() -> &'static Config {
 	static INSTANCE: OnceLock<Config> = OnceLock::new();
 
-	INSTANCE.get_or_init(|| {
-		Config::load_from_env().unwrap_or_else(|ex| {
-			panic!("FATAL - WHILE LOADING CONF - Cause: {ex:?}")
-		})
-	})
+	INSTANCE.get_or_init(|| Config::parse())
 }
 
-#[allow(non_snake_case)]
+/// Type alias for a byte vector.
+///
+/// This is needed because if you specify `Vec<u8>`, then clap will assume you want multiple `u8`
+/// arguments. By aliasing this, we tell clap that instead we want a single argument that is a byte
+/// vector.
+type ByteVec = Vec<u8>;
+
+/// Config options.
+#[derive(Parser, Debug)]
 pub struct Config {
-	// -- Crypt
-	pub PWD_KEY: Vec<u8>,
+	/// Password key.
+	#[clap(long, env = "SERVICE_PWD_KEY", value_parser = base64_url::decode)]
+	pub pwd_key: ByteVec,
 
-	pub TOKEN_KEY: Vec<u8>,
-	pub TOKEN_DURATION_SEC: f64,
+	/// Token key.
+	#[clap(long, env = "SERVICE_TOKEN_KEY", value_parser = base64_url::decode)]
+	pub token_key: ByteVec,
 
-	// -- Db
-	pub DB_URL: String,
+	/// Token lifetime duration.
+	#[clap(long, env = "SERVICE_TOKEN_DURATION_SEC")]
+	pub token_duration_sec: f64,
 
-	// -- Web
-	pub WEB_FOLDER: String,
-}
+	/// Database URL.
+	#[clap(long, env = "SERVICE_DB_URL")]
+	pub db_url: String,
 
-impl Config {
-	fn load_from_env() -> Result<Config> {
-		Ok(Config {
-			// -- Crypt
-			PWD_KEY: get_env_b64u_as_u8s("SERVICE_PWD_KEY")?,
-
-			TOKEN_KEY: get_env_b64u_as_u8s("SERVICE_TOKEN_KEY")?,
-			TOKEN_DURATION_SEC: get_env_parse("SERVICE_TOKEN_DURATION_SEC")?,
-
-			// -- Db
-			DB_URL: get_env("SERVICE_DB_URL")?,
-
-			// -- Web
-			WEB_FOLDER: get_env("SERVICE_WEB_FOLDER")?,
-		})
-	}
-}
-
-fn get_env(name: &'static str) -> Result<String> {
-	env::var(name).map_err(|_| Error::ConfigMissingEnv(name))
-}
-
-fn get_env_parse<T: FromStr>(name: &'static str) -> Result<T> {
-	let val = get_env(name)?;
-	val.parse::<T>().map_err(|_| Error::ConfigWrongFormat(name))
-}
-
-fn get_env_b64u_as_u8s(name: &'static str) -> Result<Vec<u8>> {
-	base64_url::decode(&get_env(name)?).map_err(|_| Error::ConfigWrongFormat(name))
+	/// Folder for web assets.
+	#[clap(long, env = "SERVICE_WEB_FOLDER")]
+	pub web_folder: String,
 }

--- a/src/crypt/pwd.rs
+++ b/src/crypt/pwd.rs
@@ -4,7 +4,7 @@ use crate::crypt::{encrypt_into_b64u, EncryptContent};
 
 /// Encrypt the password with the default scheme.
 pub fn encrypt_pwd(enc_content: &EncryptContent) -> Result<String> {
-	let key = &config().PWD_KEY;
+	let key = &config().pwd_key;
 
 	let encrypted = encrypt_into_b64u(key, enc_content)?;
 

--- a/src/crypt/token.rs
+++ b/src/crypt/token.rs
@@ -55,12 +55,12 @@ impl Display for Token {
 
 pub fn generate_web_token(user: &str, salt: &str) -> Result<Token> {
 	let config = &config();
-	_generate_token(user, config.TOKEN_DURATION_SEC, salt, &config.TOKEN_KEY)
+	_generate_token(user, config.token_duration_sec, salt, &config.token_key)
 }
 
 pub fn validate_web_token(origin_token: &Token, salt: &str) -> Result<()> {
 	let config = &config();
-	_validate_token_sign_and_exp(origin_token, salt, &config.TOKEN_KEY)?;
+	_validate_token_sign_and_exp(origin_token, salt, &config.token_key)?;
 
 	Ok(())
 }
@@ -187,7 +187,7 @@ mod tests {
 		let fx_user = "user_one";
 		let fx_salt = "pepper";
 		let fx_duration_sec = 0.02; // 20ms
-		let token_key = &config().TOKEN_KEY;
+		let token_key = &config().token_key;
 		let fx_token =
 			_generate_token(fx_user, fx_duration_sec, fx_salt, token_key)?;
 
@@ -207,7 +207,7 @@ mod tests {
 		let fx_user = "user_one";
 		let fx_salt = "pepper";
 		let fx_duration_sec = 0.01; // 10ms
-		let token_key = &config().TOKEN_KEY;
+		let token_key = &config().token_key;
 		let fx_token =
 			_generate_token(fx_user, fx_duration_sec, fx_salt, token_key)?;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,13 @@
 use crate::model;
+use std::borrow::Cow;
 
 pub type Result<T> = core::result::Result<T, Error>;
 
 #[derive(Debug)]
 pub enum Error {
 	// -- Config
-	ConfigMissingEnv(&'static str),
-	ConfigWrongFormat(&'static str),
+	ConfigMissingEnv(Cow<'static, str>),
+	ConfigWrongFormat(Cow<'static, str>),
 
 	// -- Modules
 	Model(model::Error),

--- a/src/model/store/mod.rs
+++ b/src/model/store/mod.rs
@@ -15,7 +15,7 @@ pub type Db = Pool<Postgres>;
 pub async fn new_db_pool() -> Result<Db> {
 	PgPoolOptions::new()
 		.max_connections(5)
-		.connect(&config().DB_URL)
+		.connect(&config().db_url)
 		.await
 		.map_err(|ex| Error::FailToCreatePool(ex.to_string()))
 }

--- a/src/web/routes_static.rs
+++ b/src/web/routes_static.rs
@@ -12,7 +12,7 @@ pub fn serve_dir() -> MethodRouter {
 	}
 
 	any_service(
-		ServeDir::new(&config().WEB_FOLDER)
+		ServeDir::new(&config().web_folder)
 			.not_found_service(handle_404.into_service()),
 	)
 }


### PR DESCRIPTION
Hey! Awesome project here. 

Depending on how much free time I have, I may make some PRs to show you how I typically structure Rust backend components as I review this code base and watch your tutorial. I think there are some nice patterns that might be useful to you. Feel free to ignore these PRs if you do not agree with my patterns, I just wanted to put them out there because I think they are neat!

This PR does two things:

- Uses the `clap` crate for the Config struct. The `clap` crate allows for easily building Config structs that support both command-line as well as environment options. Using this crate eliminates some manual code and makes the Config struct more readable.

- Renames the config options to be lower-case to abide by the Rust convention.

Cheers!