### PR TITLE
Added txn_rollback…

### DIFF
--- a/crates/libs/lib-core/src/model/store/dbx/error.rs
+++ b/crates/libs/lib-core/src/model/store/dbx/error.rs
@@ -10,6 +10,7 @@ pub enum Error {
 	TxnCantCommitNoOpenTxn,
 	CannotBeginTxnWithTxnFalse,
 	CannotCommitTxnWithTxnFalse,
+	NoTxn,
 
 	// -- Externals
 	#[from]


### PR DESCRIPTION
Allowing users to call perform multiple operations that are logically grouped together, rolling back the operations if there was an error anywhere during the transaction. You would

1. `mm.dbx().begin_txn()`
2. perform your operations
3. check if there was an error
4. if there was an error call `mm.dbx().rollback_txn()`
5. otherwise call `mm.dbx().commit_txn()` to complete the logical batch of operations

An example of a test might look like this for an example model `unavailability.rs` where `UnavailabilityBmc::create_multiple_unavailabilities(ctx: &Ctx, mm: &ModelManager, unavails: Vec<UnavailabilityForCreate>)` which simply represents a `Bmc` function performing multiple operations.

```rust
    #[tokio::test]
    #[serial]
    async fn test_unavailability_rollback_on_error() -> Result<()> {
        let (ctx, mm) = setup().await;

        mm.dbx().begin_txn().await?;

        let txn_ops = || async {
            let erroneous_unavails = vec![
                UnavailabilityForCreate {
                    employee_id: Some(1000), //this one is valid
                    patient_id: None,
                    from_date: date!(2022 - 01 - 01),
                    to_date: date!(2022 - 01 - 02),
                    start_time: time!(9:00),
                    end_time: time!(17:00),
                },
                UnavailabilityForCreate {
                    employee_id: Some(0), // this will cause an error due to invalid data
                    patient_id: None,
                    from_date: date!(2022 - 01 - 01),
                    to_date: date!(2022 - 01 - 02),
                    start_time: time!(9:00),
                    end_time: time!(17:00),
                },
            ];

            UnavailabilityBmc::create_multiple_unavailabilities(
                &ctx,
                &mm,
                erroneous_unavails,
            )
            .await?;
            Ok::<(), super::Error>(())
        };

        if let Err(_) = txn_ops().await {
            mm.dbx().rollback_txn().await?;
        } else {
            mm.dbx().commit_txn().await?;
        }

        let unavails = UnavailabilityBmc::list(&ctx, &mm, None, None).await?;

        assert!(unavails.len() == 0);

        Ok(())
    }
 ```