### PR TITLE
added count to crud_fns and macro

### DIFF
--- a/crates/libs/lib-core/src/model/agent.rs
+++ b/crates/libs/lib-core/src/model/agent.rs
@@ -246,6 +246,33 @@ mod tests {
 
 		Ok(())
 	}
+	#[serial]
+	#[tokio::test]
+	async fn test_count_ok() -> Result<()> {
+		// -- Setup & Fixtures
+		let mm = _dev_utils::init_test().await;
+		let ctx = Ctx::root_ctx();
+
+		let fx_agent_names = &["test_list_ok agent 01", "test_list_ok agent 02"];
+		seed_agents(&ctx, &mm, fx_agent_names).await?;
+
+		// -- Exec
+		let agent_filter: AgentFilter = serde_json::from_value(json!(
+			{
+				"name": {"$contains": "list_ok agent"}
+			}
+		))?;
+		let count = AgentBmc::count(&ctx, &mm, Some(vec![agent_filter])).await?;
+
+		// -- Check
+		assert_eq!(count, 2);
+
+		// -- Clean
+		let count = clean_agents(&ctx, &mm, "test_list_ok agent").await?;
+		assert_eq!(count, 2, "Should have cleaned 2 agents");
+
+		Ok(())
+	}
 }
 
 // endregion: --- Tests

--- a/crates/libs/lib-core/src/model/base/crud_fns.rs
+++ b/crates/libs/lib-core/src/model/base/crud_fns.rs
@@ -168,15 +168,12 @@ where
 
 	let query_str = query.to_string(PostgresQueryBuilder);
 
-	let result = sqlx::query(&query_str).fetch_one(db).await.map_err(|e| {
-		println!("{e:#?}");
-		Error::CountFail
-	})?;
+	let result = sqlx::query(&query_str)
+		.fetch_one(db)
+		.await
+		.map_err(|_| Error::CountFail)?;
 
-	let count: i64 = result.try_get("count").map_err(|e| {
-		println!("{e:#?}");
-		Error::CountFail
-	})?;
+	let count: i64 = result.try_get("count").map_err(|_| Error::CountFail)?;
 
 	Ok(count)
 }

--- a/crates/libs/lib-core/src/model/base/macro_utils.rs
+++ b/crates/libs/lib-core/src/model/base/macro_utils.rs
@@ -47,6 +47,14 @@ macro_rules! generate_common_bmc_fns {
 				) -> Result<Vec<$entity>> {
 					base::list::<Self, _, _>(ctx, mm, filter, list_options).await
 				}
+
+				pub async fn count(
+					ctx: &Ctx,
+					mm: &ModelManager,
+					filter: Option<Vec<$filter>>,
+				) -> Result<i64> {
+					base::count::<Self, _>(ctx, mm, filter).await
+				}
 			)?
 
 			$(

--- a/crates/libs/lib-core/src/model/error.rs
+++ b/crates/libs/lib-core/src/model/error.rs
@@ -20,6 +20,8 @@ pub enum Error {
 		actual: i64,
 	},
 
+	CountFail,
+
 	// -- DB
 	UserAlreadyExists {
 		username: String,


### PR DESCRIPTION
added `count` to base

```rust
	async fn test_count_ok() -> Result<()> {
		// -- Setup & Fixtures
		let mm = _dev_utils::init_test().await;
		let ctx = Ctx::root_ctx();

		let fx_agent_names = &["test_list_ok agent 01", "test_list_ok agent 02"];
		seed_agents(&ctx, &mm, fx_agent_names).await?;

		// -- Exec
		let agent_filter: AgentFilter = serde_json::from_value(json!(
			{
				"name": {"$contains": "list_ok agent"}
			}
		))?;
		let count = AgentBmc::count(&ctx, &mm, Some(vec![agent_filter])).await?;

		// -- Check
		assert_eq!(count, 2);

		// -- Clean
		let count = clean_agents(&ctx, &mm, "test_list_ok agent").await?;
		assert_eq!(count, 2, "Should have cleaned 2 agents");

		Ok(())
	}
```