### PR TITLE
fixed create_many

### DIFF
--- a/crates/libs/lib-core/src/model/base/crud_fns.rs
+++ b/crates/libs/lib-core/src/model/base/crud_fns.rs
@@ -59,7 +59,7 @@ where
 	let mut query = Query::insert();
 
 	for item in data {
-		let mut fields = item.not_none_sea_fields();
+		let mut fields = item.all_sea_fields();
 		prep_fields_for_create::<MC>(&mut fields, user_id);
 		let (columns, sea_values) = fields.for_sea_insert();
 


### PR DESCRIPTION
`item.not_none_sea_fields` may return a different number of columns per item.

The items all need to have the same number of columns, otherwise we get an error saying there are more target columns than values.

Changed `.not_none_sea_fields()` to `all_sea_fields()` to make sure the data are uniform.