### PR TITLE
Refactoring to split out reusable bits from web-server into lib-web

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,7 +5,7 @@
 [env]
 
 # Scope down tracing, to filter out external lib tracing.
-RUST_LOG="web_server=debug,lib_core=debug,lib_auth=debug,lib_utils=debug"
+RUST_LOG="web_server=debug,lib_core=debug,lib_web=debug,lib_auth=debug,lib_utils=debug"
 
 # -- Service Environment Variables
 # IMPORTANT: 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,13 @@ members = [
     "crates/libs/lib-rpc-app",    # e.g., rpc handlers for app (using rpc-router crate)
     "crates/libs/lib-auth",       # e.g., for pwd, token.
     "crates/libs/lib-core",       # e.g., model, ctx, config.
+    "crates/libs/lib-web",        # e.g., logging, common middleware etc
 
     # -- Application Services
     "crates/services/web-server",
 
     # -- Tools
-    "crates/tools/gen-key",
+    "crates/tools/gen-key", 
 ]
 
 # NOTE: Only the crates that are utilized in two or more sub-crates and benefit from global management

--- a/crates/libs/lib-web/Cargo.toml
+++ b/crates/libs/lib-web/Cargo.toml
@@ -1,16 +1,15 @@
 [package]
-name = "web-server"
+name = "lib-web"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
 # -- App Libs
 lib-utils = { path = "../../libs/lib-utils"}
-lib-rpc-app = { path = "../../libs/lib-rpc-app"}
 lib-rpc-core = { path = "../../libs/lib-rpc-core"}
 lib-auth = { path = "../../libs/lib-auth"}
 lib-core = { path = "../../libs/lib-core"}
-lib-web = { path = "../../libs/lib-web"}
+
 # -- Async
 tokio = { version = "1", features = ["full"] }
 # -- Json
@@ -32,5 +31,5 @@ uuid = {version = "1", features = ["v4","fast-rng",]}
 strum_macros = "0.26"
 derive_more = { workspace = true }
 
-[dev-dependencies]
-httpc-test = "0.1"
+[lints]
+workspace = true

--- a/crates/libs/lib-web/src/error.rs
+++ b/crates/libs/lib-web/src/error.rs
@@ -1,4 +1,4 @@
-use crate::web;
+use crate::middleware;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use derive_more::From;
@@ -27,7 +27,7 @@ pub enum Error {
 
 	// -- CtxExtError
 	#[from]
-	CtxExt(web::mw_auth::CtxExtError),
+	CtxExt(middleware::mw_auth::CtxExtError),
 
 	// -- Extractors
 	ReqStampNotInReqExt,
@@ -74,11 +74,11 @@ pub enum Error {
 /// and place them into the appropriate variant of our application error enum.
 ///
 /// - The `rpc-router` provides an `RpcHandlerError` scheme to allow application RPC handlers
-///   to return the errors they wish with minimal constraints.
+/// to return the errors they wish with minimal constraints.
 /// - This approach requires us to "unpack" those types in our code and assign them to the correct
-///   "concrete/direct" variant (not `Box<dyn Any>`...).
+/// "concrete/direct" variant (not `Box<dyn Any>`...).
 /// - If it's not an `rpc_router::Error::Handler` variant, then we can capture the `rpc_router::Error`
-///   as it is, treating all other variants as "concrete/direct" types.
+/// as it is, treating all other variants as "concrete/direct" types.
 impl From<rpc_router::CallError> for Error {
 	fn from(call_error: rpc_router::CallError) -> Self {
 		let rpc_router::CallError { id, method, error } = call_error;
@@ -137,7 +137,7 @@ impl std::error::Error for Error {}
 /// From the root error to the http status code and ClientError
 impl Error {
 	pub fn client_status_and_error(&self) -> (StatusCode, ClientError) {
-		use web::Error::*; // TODO: should change to `use web::Error as E`
+		use Error::*; // TODO: should change to `use web::Error as E`
 
 		match self {
 			// -- Login

--- a/crates/libs/lib-web/src/handlers/handlers_login.rs
+++ b/crates/libs/lib-web/src/handlers/handlers_login.rs
@@ -1,0 +1,101 @@
+use crate::error::{Error, Result};
+use crate::utils::token;
+use axum::extract::State;
+use axum::Json;
+use lib_auth::pwd::{self, ContentToHash, SchemeStatus};
+use lib_core::ctx::Ctx;
+use lib_core::model::user::{UserBmc, UserForLogin};
+use lib_core::model::ModelManager;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use tower_cookies::Cookies;
+use tracing::debug;
+
+// region:    --- Login
+pub async fn api_login_handler(
+	State(mm): State<ModelManager>,
+	cookies: Cookies,
+	Json(payload): Json<LoginPayload>,
+) -> Result<Json<Value>> {
+	debug!("{:<12} - api_login_handler", "HANDLER");
+
+	let LoginPayload {
+		username,
+		pwd: pwd_clear,
+	} = payload;
+	let root_ctx = Ctx::root_ctx();
+
+	// -- Get the user.
+	let user: UserForLogin = UserBmc::first_by_username(&root_ctx, &mm, &username)
+		.await?
+		.ok_or(Error::LoginFailUsernameNotFound)?;
+	let user_id = user.id;
+
+	// -- Validate the password.
+	let Some(pwd) = user.pwd else {
+		return Err(Error::LoginFailUserHasNoPwd { user_id });
+	};
+
+	let scheme_status = pwd::validate_pwd(
+		ContentToHash {
+			salt: user.pwd_salt,
+			content: pwd_clear.clone(),
+		},
+		pwd,
+	)
+	.await
+	.map_err(|_| Error::LoginFailPwdNotMatching { user_id })?;
+
+	// -- Update password scheme if needed
+	if let SchemeStatus::Outdated = scheme_status {
+		debug!("pwd encrypt scheme outdated, upgrading.");
+		UserBmc::update_pwd(&root_ctx, &mm, user.id, &pwd_clear).await?;
+	}
+
+	// -- Set web token.
+	token::set_token_cookie(&cookies, &user.username, user.token_salt)?;
+
+	// Create the success body.
+	let body = Json(json!({
+		"result": {
+			"success": true
+		}
+	}));
+
+	Ok(body)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LoginPayload {
+	username: String,
+	pwd: String,
+}
+// endregion: --- Login
+
+// region:    --- Logoff
+pub async fn api_logoff_handler(
+	cookies: Cookies,
+	Json(payload): Json<LogoffPayload>,
+) -> Result<Json<Value>> {
+	debug!("{:<12} - api_logoff_handler", "HANDLER");
+	let should_logoff = payload.logoff;
+
+	if should_logoff {
+		token::remove_token_cookie(&cookies)?;
+	}
+
+	// Create the success body.
+	let body = Json(json!({
+		"result": {
+			"logged_off": should_logoff
+		}
+	}));
+
+	Ok(body)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LogoffPayload {
+	logoff: bool,
+}
+// endregion: --- Logoff

--- a/crates/libs/lib-web/src/handlers/handlers_rpc.rs
+++ b/crates/libs/lib-web/src/handlers/handlers_rpc.rs
@@ -1,0 +1,76 @@
+use crate::middleware::mw_auth::CtxW;
+use axum::extract::State;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use rpc_router::resources_builder;
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+/// RPC ID and Method Capture
+/// Note: This will be injected into the Axum Response extensions so that
+///       it can be used downstream by the `mw_res_map` for logging and eventual
+///       error client JSON-RPC serialization
+#[derive(Debug)]
+pub struct RpcInfo {
+	pub id: Option<Value>,
+	pub method: String,
+}
+
+pub async fn rpc_axum_handler(
+	State(rpc_router): State<rpc_router::Router>,
+	ctx: CtxW,
+	Json(rpc_req): Json<Value>,
+) -> Response {
+	let ctx = ctx.0;
+
+	// -- Parse and RpcRequest validate the rpc_request
+	let rpc_req = match rpc_router::Request::try_from(rpc_req) {
+		Ok(rpc_req) => rpc_req,
+		Err(rpc_req_error) => {
+			let res =
+				crate::error::Error::RpcRequestParsing(rpc_req_error).into_response();
+			return res;
+		}
+	};
+
+	// -- Create the RPC Info
+	//    (will be set to the response.extensions)
+	let rpc_info = RpcInfo {
+		id: Some(rpc_req.id.clone()),
+		method: rpc_req.method.clone(),
+	};
+
+	// -- Add the request specific resources
+	// Note: Since Ctx is per axum request, we construct additional RPC resources.
+	//       These additional resources will be "overlayed" on top of the base router services,
+	//       meaning they will take precedence over the base router ones, but won't replace them.
+	let additional_resources = resources_builder![ctx].build();
+
+	// -- Exec Rpc Route
+	let rpc_call_result = rpc_router
+		.call_with_resources(rpc_req, additional_resources)
+		.await;
+
+	// -- Build Json Rpc Success Response
+	// Note: Error Json response will be generated in the mw_res_map as wil other error.
+	let res = rpc_call_result.map(|rpc_call_response| {
+		let body_response = json!({
+			"jsonrpc": "2.0",
+			"id": rpc_call_response.id,
+			"result": rpc_call_response.value
+		});
+		Json(body_response)
+	});
+
+	// -- Create and Update Axum Response
+	// Note: We store data in the Axum Response extensions so that
+	//       we can unpack it in the `mw_res_map` for client-side rendering.
+	//       This approach centralizes error handling for the client at the `mw_res_map` module
+	let res: crate::error::Result<_> = res.map_err(crate::error::Error::from);
+	let mut res = res.into_response();
+	// Note: Here, add the capture RpcInfo (RPC ID and method) into the Axum response to be used
+	//       later in the `mw_res_map` for RequestLineLogging, and eventual JSON-RPC error serialization.
+	res.extensions_mut().insert(Arc::new(rpc_info));
+
+	res
+}

--- a/crates/libs/lib-web/src/handlers/mod.rs
+++ b/crates/libs/lib-web/src/handlers/mod.rs
@@ -1,0 +1,2 @@
+pub mod handlers_login;
+pub mod handlers_rpc;

--- a/crates/libs/lib-web/src/lib.rs
+++ b/crates/libs/lib-web/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod error;
+pub mod log;
+pub mod handlers;
+pub mod middleware;
+pub mod routes;
+pub mod utils;

--- a/crates/libs/lib-web/src/log/mod.rs
+++ b/crates/libs/lib-web/src/log/mod.rs
@@ -1,7 +1,7 @@
-use crate::web::mw_req_stamp::ReqStamp;
-use crate::web::routes_rpc::RpcInfo;
-use crate::web::{self, ClientError};
-use crate::Result;
+use crate::middleware::mw_req_stamp::ReqStamp;
+use crate::handlers::handlers_rpc::RpcInfo;
+use crate::error::{Error, ClientError};
+use crate::error::Result;
 use axum::http::{Method, Uri};
 use lib_core::ctx::Ctx;
 use lib_utils::time::{format_time, now_utc};
@@ -17,7 +17,7 @@ pub async fn log_request(
 	req_stamp: ReqStamp,
 	rpc_info: Option<&RpcInfo>,
 	ctx: Option<Ctx>,
-	web_error: Option<&web::Error>,
+	web_error: Option<&Error>,
 	client_error: Option<ClientError>,
 ) -> Result<()> {
 	// -- Prep error

--- a/crates/libs/lib-web/src/middleware/mod.rs
+++ b/crates/libs/lib-web/src/middleware/mod.rs
@@ -1,0 +1,3 @@
+pub mod mw_auth;
+pub mod mw_req_stamp;
+pub mod mw_res_map;

--- a/crates/libs/lib-web/src/middleware/mw_auth.rs
+++ b/crates/libs/lib-web/src/middleware/mw_auth.rs
@@ -1,5 +1,5 @@
-use crate::web::{set_token_cookie, AUTH_TOKEN};
-use crate::web::{Error, Result};
+use crate::error::{Error, Result};
+use crate::utils::token::{set_token_cookie, AUTH_TOKEN};
 use axum::async_trait;
 use axum::body::Body;
 use axum::extract::{FromRequestParts, State};

--- a/crates/libs/lib-web/src/middleware/mw_req_stamp.rs
+++ b/crates/libs/lib-web/src/middleware/mw_req_stamp.rs
@@ -1,4 +1,4 @@
-use crate::web::{Error, Result};
+use crate::error::{Error, Result};
 use axum::async_trait;
 use axum::body::Body;
 use axum::extract::FromRequestParts;

--- a/crates/libs/lib-web/src/middleware/mw_res_map.rs
+++ b/crates/libs/lib-web/src/middleware/mw_res_map.rs
@@ -1,8 +1,9 @@
 use crate::log::log_request;
-use crate::web::mw_auth::CtxW;
-use crate::web::mw_req_stamp::ReqStamp;
-use crate::web::routes_rpc::RpcInfo;
-use crate::web::{self};
+use crate::middleware::mw_auth::CtxW;
+use crate::middleware::mw_req_stamp::ReqStamp;
+use crate::handlers::handlers_rpc::RpcInfo;
+use crate::error::Error;
+
 use axum::http::{Method, Uri};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
@@ -26,7 +27,7 @@ pub async fn mw_reponse_map(
 	let rpc_info = res.extensions().get::<Arc<RpcInfo>>().map(Arc::as_ref);
 
 	// -- Get the eventual response error.
-	let web_error = res.extensions().get::<Arc<web::Error>>().map(Arc::as_ref);
+	let web_error = res.extensions().get::<Arc<Error>>().map(Arc::as_ref);
 	let client_status_error = web_error.map(|se| se.client_status_and_error());
 
 	// -- If client error, build the new reponse.

--- a/crates/libs/lib-web/src/routes/mod.rs
+++ b/crates/libs/lib-web/src/routes/mod.rs
@@ -1,0 +1,1 @@
+pub mod routes_static;

--- a/crates/libs/lib-web/src/routes/routes_static.rs
+++ b/crates/libs/lib-web/src/routes/routes_static.rs
@@ -1,4 +1,3 @@
-use crate::web_config;
 use axum::handler::HandlerWithoutStateExt;
 use axum::http::StatusCode;
 use axum::routing::{any_service, MethodRouter};
@@ -6,13 +5,13 @@ use tower_http::services::ServeDir;
 
 // Note: Here we can just return a MethodRouter rather than a full Router
 //       since ServeDir is a service.
-pub fn serve_dir() -> MethodRouter {
+pub fn serve_dir(web_folder: &'static String) -> MethodRouter {
 	async fn handle_404() -> (StatusCode, &'static str) {
 		(StatusCode::NOT_FOUND, "Resource not found.")
 	}
 
 	any_service(
-		ServeDir::new(&web_config().WEB_FOLDER)
+		ServeDir::new(web_folder)
 			.not_found_service(handle_404.into_service()),
 	)
 }

--- a/crates/libs/lib-web/src/utils/mod.rs
+++ b/crates/libs/lib-web/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod token;

--- a/crates/libs/lib-web/src/utils/token.rs
+++ b/crates/libs/lib-web/src/utils/token.rs
@@ -1,0 +1,31 @@
+
+pub use crate::error::ClientError;
+pub use crate::error::{Error, Result};
+use lib_auth::token::generate_web_token;
+use tower_cookies::{Cookie, Cookies};
+use uuid::Uuid;
+
+// endregion: --- Modules
+
+pub(crate) const AUTH_TOKEN: &str = "auth-token";
+
+pub(crate) fn set_token_cookie(cookies: &Cookies, user: &str, salt: Uuid) -> Result<()> {
+	let token = generate_web_token(user, salt)?;
+
+	let mut cookie = Cookie::new(AUTH_TOKEN, token.to_string());
+	cookie.set_http_only(true);
+	cookie.set_path("/");
+
+	cookies.add(cookie);
+
+	Ok(())
+}
+
+pub(crate) fn remove_token_cookie(cookies: &Cookies) -> Result<()> {
+	let mut cookie = Cookie::from(AUTH_TOKEN);
+	cookie.set_path("/");
+
+	cookies.remove(cookie);
+
+	Ok(())
+}

--- a/crates/services/web-server/src/main.rs
+++ b/crates/services/web-server/src/main.rs
@@ -2,16 +2,19 @@
 
 mod config;
 mod error;
-mod log;
 mod web;
 
 pub use self::error::{Error, Result};
 use config::web_config;
 
-use crate::web::mw_auth::{mw_ctx_require, mw_ctx_resolver};
-use crate::web::mw_req_stamp::mw_req_stamp_resolver;
-use crate::web::mw_res_map::mw_reponse_map;
-use crate::web::{routes_login, routes_static};
+use lib_web::middleware::mw_auth::{mw_ctx_require, mw_ctx_resolver};
+use lib_web::middleware::mw_req_stamp::mw_req_stamp_resolver;
+use lib_web::middleware::mw_res_map::mw_reponse_map;
+use lib_web::routes::routes_static;
+
+use crate::web::routes_login;
+
+
 use axum::{middleware, Router};
 use lib_core::_dev_utils;
 use lib_core::model::ModelManager;
@@ -46,7 +49,7 @@ async fn main() -> Result<()> {
 		.layer(middleware::from_fn_with_state(mm.clone(), mw_ctx_resolver))
 		.layer(CookieManagerLayer::new())
 		.layer(middleware::from_fn(mw_req_stamp_resolver))
-		.fallback_service(routes_static::serve_dir());
+		.fallback_service(routes_static::serve_dir(&web_config().WEB_FOLDER));
 
 	// region:    --- Start Server
 	// Note: For this block, ok to unwrap.

--- a/crates/services/web-server/src/web/mod.rs
+++ b/crates/services/web-server/src/web/mod.rs
@@ -1,40 +1,5 @@
 // region:    --- Modules
-
-mod error;
-pub mod mw_auth;
-pub mod mw_req_stamp;
-pub mod mw_res_map;
 pub mod routes_login;
 pub mod routes_rpc;
-pub mod routes_static;
-
-pub use self::error::ClientError;
-pub use self::error::{Error, Result};
-use lib_auth::token::generate_web_token;
-use tower_cookies::{Cookie, Cookies};
-use uuid::Uuid;
 
 // endregion: --- Modules
-
-pub const AUTH_TOKEN: &str = "auth-token";
-
-fn set_token_cookie(cookies: &Cookies, user: &str, salt: Uuid) -> Result<()> {
-	let token = generate_web_token(user, salt)?;
-
-	let mut cookie = Cookie::new(AUTH_TOKEN, token.to_string());
-	cookie.set_http_only(true);
-	cookie.set_path("/");
-
-	cookies.add(cookie);
-
-	Ok(())
-}
-
-fn remove_token_cookie(cookies: &Cookies) -> Result<()> {
-	let mut cookie = Cookie::from(AUTH_TOKEN);
-	cookie.set_path("/");
-
-	cookies.remove(cookie);
-
-	Ok(())
-}

--- a/crates/services/web-server/src/web/routes_login.rs
+++ b/crates/services/web-server/src/web/routes_login.rs
@@ -1,108 +1,11 @@
-use crate::web::{self, remove_token_cookie, Error, Result};
-use axum::extract::State;
 use axum::routing::post;
-use axum::{Json, Router};
-use lib_auth::pwd::{self, ContentToHash, SchemeStatus};
-use lib_core::ctx::Ctx;
-use lib_core::model::user::{UserBmc, UserForLogin};
+use axum::Router;
 use lib_core::model::ModelManager;
-use serde::Deserialize;
-use serde_json::{json, Value};
-use tower_cookies::Cookies;
-use tracing::debug;
+use lib_web::handlers::handlers_login;
 
 pub fn routes(mm: ModelManager) -> Router {
 	Router::new()
-		.route("/api/login", post(api_login_handler))
-		.route("/api/logoff", post(api_logoff_handler))
+		.route("/api/login", post(handlers_login::api_login_handler))
+		.route("/api/logoff", post(handlers_login::api_logoff_handler))
 		.with_state(mm)
 }
-
-// region:    --- Login
-async fn api_login_handler(
-	State(mm): State<ModelManager>,
-	cookies: Cookies,
-	Json(payload): Json<LoginPayload>,
-) -> Result<Json<Value>> {
-	debug!("{:<12} - api_login_handler", "HANDLER");
-
-	let LoginPayload {
-		username,
-		pwd: pwd_clear,
-	} = payload;
-	let root_ctx = Ctx::root_ctx();
-
-	// -- Get the user.
-	let user: UserForLogin = UserBmc::first_by_username(&root_ctx, &mm, &username)
-		.await?
-		.ok_or(Error::LoginFailUsernameNotFound)?;
-	let user_id = user.id;
-
-	// -- Validate the password.
-	let Some(pwd) = user.pwd else {
-		return Err(Error::LoginFailUserHasNoPwd { user_id });
-	};
-
-	let scheme_status = pwd::validate_pwd(
-		ContentToHash {
-			salt: user.pwd_salt,
-			content: pwd_clear.clone(),
-		},
-		pwd,
-	)
-	.await
-	.map_err(|_| Error::LoginFailPwdNotMatching { user_id })?;
-
-	// -- Update password scheme if needed
-	if let SchemeStatus::Outdated = scheme_status {
-		debug!("pwd encrypt scheme outdated, upgrading.");
-		UserBmc::update_pwd(&root_ctx, &mm, user.id, &pwd_clear).await?;
-	}
-
-	// -- Set web token.
-	web::set_token_cookie(&cookies, &user.username, user.token_salt)?;
-
-	// Create the success body.
-	let body = Json(json!({
-		"result": {
-			"success": true
-		}
-	}));
-
-	Ok(body)
-}
-
-#[derive(Debug, Deserialize)]
-struct LoginPayload {
-	username: String,
-	pwd: String,
-}
-// endregion: --- Login
-
-// region:    --- Logoff
-async fn api_logoff_handler(
-	cookies: Cookies,
-	Json(payload): Json<LogoffPayload>,
-) -> Result<Json<Value>> {
-	debug!("{:<12} - api_logoff_handler", "HANDLER");
-	let should_logoff = payload.logoff;
-
-	if should_logoff {
-		remove_token_cookie(&cookies)?;
-	}
-
-	// Create the success body.
-	let body = Json(json!({
-		"result": {
-			"logged_off": should_logoff
-		}
-	}));
-
-	Ok(body)
-}
-
-#[derive(Debug, Deserialize)]
-struct LogoffPayload {
-	logoff: bool,
-}
-// endregion: --- Logoff

--- a/crates/services/web-server/src/web/routes_rpc.rs
+++ b/crates/services/web-server/src/web/routes_rpc.rs
@@ -1,23 +1,8 @@
-use crate::web::mw_auth::CtxW;
-use axum::extract::State;
-use axum::response::{IntoResponse, Response};
 use axum::routing::post;
-use axum::{Json, Router};
+use axum::Router;
 use lib_core::model::ModelManager;
+use lib_web::handlers::handlers_rpc;
 use lib_rpc_app::all_rpc_router_builder;
-use rpc_router::resources_builder;
-use serde_json::{json, Value};
-use std::sync::Arc;
-
-/// RPC ID and Method Capture
-/// Note: This will be injected into the Axum Response extensions so that
-///       it can be used downstream by the `mw_res_map` for logging and eventual
-///       error client JSON-RPC serialization
-#[derive(Debug)]
-pub struct RpcInfo {
-	pub id: Option<Value>,
-	pub method: String,
-}
 
 ///  Build the Axum router for '/api/rpc'
 /// Note: This will build the `rpc-router::Router` that will be used by the
@@ -31,65 +16,6 @@ pub fn routes(mm: ModelManager) -> Router {
 
 	// Build the Axum Router for '/rpc'
 	Router::new()
-		.route("/rpc", post(rpc_axum_handler))
+		.route("/rpc", post(handlers_rpc::rpc_axum_handler))
 		.with_state(rpc_router)
-}
-
-async fn rpc_axum_handler(
-	State(rpc_router): State<rpc_router::Router>,
-	ctx: CtxW,
-	Json(rpc_req): Json<Value>,
-) -> Response {
-	let ctx = ctx.0;
-
-	// -- Parse and RpcRequest validate the rpc_request
-	let rpc_req = match rpc_router::Request::try_from(rpc_req) {
-		Ok(rpc_req) => rpc_req,
-		Err(rpc_req_error) => {
-			let res =
-				crate::web::Error::RpcRequestParsing(rpc_req_error).into_response();
-			return res;
-		}
-	};
-
-	// -- Create the RPC Info
-	//    (will be set to the response.extensions)
-	let rpc_info = RpcInfo {
-		id: Some(rpc_req.id.clone()),
-		method: rpc_req.method.clone(),
-	};
-
-	// -- Add the request specific resources
-	// Note: Since Ctx is per axum request, we construct additional RPC resources.
-	//       These additional resources will be "overlayed" on top of the base router services,
-	//       meaning they will take precedence over the base router ones, but won't replace them.
-	let additional_resources = resources_builder![ctx].build();
-
-	// -- Exec Rpc Route
-	let rpc_call_result = rpc_router
-		.call_with_resources(rpc_req, additional_resources)
-		.await;
-
-	// -- Build Json Rpc Success Response
-	// Note: Error Json response will be generated in the mw_res_map as wil other error.
-	let res = rpc_call_result.map(|rpc_call_response| {
-		let body_response = json!({
-			"jsonrpc": "2.0",
-			"id": rpc_call_response.id,
-			"result": rpc_call_response.value
-		});
-		Json(body_response)
-	});
-
-	// -- Create and Update Axum Response
-	// Note: We store data in the Axum Response extensions so that
-	//       we can unpack it in the `mw_res_map` for client-side rendering.
-	//       This approach centralizes error handling for the client at the `mw_res_map` module
-	let res: crate::web::Result<_> = res.map_err(crate::web::Error::from);
-	let mut res = res.into_response();
-	// Note: Here, add the capture RpcInfo (RPC ID and method) into the Axum response to be used
-	//       later in the `mw_res_map` for RequestLineLogging, and eventual JSON-RPC error serialization.
-	res.extensions_mut().insert(Arc::new(rpc_info));
-
-	res
 }


### PR DESCRIPTION
Second round of refactoring to split web-server into lib-web so we can have multiple web-servers using the same lib-web. Minimum possible refactoring was done.

## Validation
 - ✔️builds
 - ✔️ quick_dev was run on both original rust10x main and this refactored fork and their stdout compared. The only diffs were related to the token and time-stamps.
   - [orig_example_log.txt](https://github.com/user-attachments/files/16490998/orig_example_log.txt)
   - [modified_example_log.txt](https://github.com/user-attachments/files/16490999/modified_example_log.txt)

 
## Naming

While moving the files over from their consolidated `web-server/src/web` locaiton, there was an opportunity to move them into names that were meaningful in axum. As as initial cut, I chose the following names. Please rename appropriately as needed if this PR is merged.

```console
├── Cargo.toml
└── src
    ├── error.rs
    ├── handlers
    │   ├── handlers_login.rs
    │   ├── handlers_rpc.rs
    │   └── mod.rs
    ├── lib.rs
    ├── log
    │   └── mod.rs
    ├── middleware
    │   ├── mod.rs
    │   ├── mw_auth.rs
    │   ├── mw_req_stamp.rs
    │   └── mw_res_map.rs
    ├── routes
    │   ├── mod.rs
    │   └── routes_static.rs
    └── utils
        ├── mod.rs
        └── token.rs
```

## web-server

web-server assembles the middleware and handlers in `lib-web` into it's server setup and routes.